### PR TITLE
Add pure entry to manually test in jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,22 @@ console.log('Mocked console.log');
 restore();
 ```
 
+## Manually mocking with Jest
+
+If your tests run with Jest then the `global.console` is automatically mocked. If you wish to have more control and manually mock it, then import the package from `pure` entry.
+
+```js
+import { createConsole, mockConsole } from 'console-testing-library/pure';
+
+let restore = () => {};
+
+beforeEach(() => {
+  restore = mockConsole(createConsole());
+});
+
+afterEach(() => restore());
+```
+
 ## Custom matchers
 
 It's often recommended to use `console-testing-library` with Jest's [`toMatchInlineSnapshot`](https://jestjs.io/docs/en/expect#tomatchinlinesnapshotpropertymatchers-inlinesnapshot) matcher. It makes it really easy to test the console output with confidence.

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,4 +1,4 @@
-const { getLog, createConsole, mockConsole, silenceConsole } = require('./');
+const { getLog, createConsole, mockConsole, silenceConsole } = require('..');
 
 expect(jest.isMockFunction(console.log)).toBe(false);
 

--- a/__tests__/pure.js
+++ b/__tests__/pure.js
@@ -1,0 +1,5 @@
+require('../pure');
+
+test('it should be pure', () => {
+  expect(jest.isMockFunction(console.log)).toBe(false);
+});

--- a/package.json
+++ b/package.json
@@ -3,12 +3,16 @@
   "version": "0.2.2",
   "description": "Testing console the right way",
   "type": "module",
-  "main": "dist/console-testing-library.js",
+  "main": "dist/index.js",
   "typings": "index.d.ts",
   "exports": {
     ".": {
-      "require": "dist/console-testing-library.js",
-      "default": "index.js"
+      "require": "dist/index.js",
+      "default": "src/index.js"
+    },
+    "./pure": {
+      "require": "dist/pure.js",
+      "default": "src/pure.js"
     }
   },
   "repository": "https://github.com/kevin940726/console-testing-library.git",
@@ -16,7 +20,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "build": "babel index.js -o dist/console-testing-library.js",
+    "build": "babel src -d dist",
     "test": "jest",
     "prepare": "yarn build && yarn test"
   },

--- a/pure.js
+++ b/pure.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/pure.js');

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,18 @@
+import { mockConsole, createConsole } from './pure';
+
+// Keep an instance of the original console and export it
+const originalConsole = global.console;
+global.originalConsole = originalConsole;
+export { originalConsole };
+
+if (typeof beforeEach === 'function' && typeof afterEach === 'function') {
+  let restore = () => {};
+
+  beforeEach(() => {
+    restore = mockConsole(createConsole());
+  });
+
+  afterEach(() => restore());
+}
+
+export * from './pure';

--- a/src/pure.js
+++ b/src/pure.js
@@ -4,11 +4,6 @@ import util from 'util';
 import { toMatchInlineSnapshot } from 'jest-snapshot';
 import prettyFormat from 'pretty-format';
 
-// Keep an instance of the original console and export it
-const originalConsole = global.console;
-global.originalConsole = originalConsole;
-export { originalConsole };
-
 const INSPECT_SYMBOL = util.inspect.custom;
 
 const instances = new WeakMap();
@@ -210,17 +205,7 @@ export function silenceConsole(
 }
 
 export function restore() {
-  global.console = originalConsole;
-}
-
-if (typeof beforeEach === 'function' && typeof afterEach === 'function') {
-  let restore = () => {};
-
-  beforeEach(() => {
-    restore = mockConsole(createConsole());
-  });
-
-  afterEach(() => restore());
+  global.console = global.originalConsole;
 }
 
 if (typeof expect === 'function' && typeof expect.extend === 'function') {


### PR DESCRIPTION
Taken advise from @phryneas, provide a `pure` entry to let the user to manually mock the console. 👍 

The naming and structure is heavily inspired from [react-testing-library](https://github.com/testing-library/react-testing-library/blob/master/src/index.js)