### PR TITLE
Expose new option 'stripsAnsi'

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can strip out ansi characters 1`] = `"Hello World!"`;
+
+exports[`simple with ansi characters 1`] = `"Hello [31mWorld![39m"`;

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,4 +1,5 @@
 const { getLog, createConsole, mockConsole, silenceConsole } = require('..');
+const chalk = require('chalk');
 
 expect(jest.isMockFunction(console.log)).toBe(false);
 
@@ -6,6 +7,22 @@ test('simple', () => {
   console.log('Hello %s!', 'World');
 
   expect(getLog().log).toMatchInlineSnapshot(`"Hello World!"`);
+});
+
+test('simple with ansi characters', () => {
+  console.log(`Hello ${chalk.red('World!')}`);
+
+  expect(getLog().log).toMatchSnapshot();
+});
+
+test('can strip out ansi characters', () => {
+  const targetConsole = createConsole({ stripsAnsi: true });
+  const restore = mockConsole(targetConsole);
+
+  console.log(`Hello ${chalk.red('World!')}`);
+
+  expect(getLog().log).toMatchSnapshot();
+  restore();
 });
 
 test('advanced', () => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ export const originalConsole = Console;
 
 type Options = {
   isSilent?: boolean;
+  stripsAnsi?: boolean;
 };
 
 export enum ConsoleLevels {

--- a/package.json
+++ b/package.json
@@ -26,13 +26,15 @@
   },
   "dependencies": {
     "jest-snapshot": "^24.9.0",
-    "pretty-format": "^24.9.0"
+    "pretty-format": "^24.9.0",
+    "strip-ansi": "^6.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.4",
     "@babel/core": "^7.7.4",
     "@babel/preset-env": "^7.7.4",
-    "canopic": "^0.2.1"
+    "canopic": "^0.2.1",
+    "chalk": "^4.1.0"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/pure.js
+++ b/src/pure.js
@@ -3,6 +3,7 @@ import { Writable } from 'stream';
 import util from 'util';
 import { toMatchInlineSnapshot } from 'jest-snapshot';
 import prettyFormat from 'pretty-format';
+import stripAnsi from 'strip-ansi';
 
 const INSPECT_SYMBOL = util.inspect.custom;
 
@@ -24,7 +25,10 @@ const LEVELS = {
   error: ['error', 'assert'],
 };
 
-export function createConsole({ isSilent: defaultIsSilent = true } = {}) {
+export function createConsole({
+  isSilent: defaultIsSilent = true,
+  stripsAnsi: defaultStripsAnsi = false,
+} = {}) {
   let logs = [];
   let records = {};
   let levels = {
@@ -36,6 +40,7 @@ export function createConsole({ isSilent: defaultIsSilent = true } = {}) {
   let currentLevel = undefined;
   let currentMethod = undefined;
   let isSilent = defaultIsSilent;
+  let stripsAnsi = defaultStripsAnsi;
   let targetConsole = undefined;
 
   const writable = new Writable({
@@ -44,7 +49,7 @@ export function createConsole({ isSilent: defaultIsSilent = true } = {}) {
         .toString('utf8')
         // Strip out the new line character in the end
         .slice(0, -1);
-      logs.push([currentLevel, message]);
+      logs.push([currentLevel, stripsAnsi ? stripAnsi(message) : message]);
       if (currentLevel && currentLevel in levels) {
         levels[currentLevel] = [levels[currentLevel], message]
           .filter(Boolean)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,6 +1086,11 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -1097,6 +1102,13 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
 
 any-observable@^0.3.0:
   version "0.3.0"
@@ -1497,6 +1509,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -1595,10 +1615,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -2528,6 +2560,11 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbols@^1.0.0:
   version "1.0.0"
@@ -5139,6 +5176,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
+
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -5172,6 +5216,13 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 symbol-observable@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
Using 'chalk' is quite standard when writing pretty console outputs.

This new option (sets to `false` by default), allows dynamic stripping
of ansi characters to make snapshot comparison easier.