### PR TITLE
Expose new option 'stripAnsi'

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,10 @@
 name: Node CI
 
-on: [push]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -192,6 +192,31 @@ beforeEach(() => {
 afterEach(() => restore());
 ```
 
+## Optionally stripping out Ansi characters
+
+When working with the console, it's not unusual to make the output a bit prettier by
+relying on libraries such as [chalk](https://www.npmjs.com/package/chalk). Those libraries rely on
+[ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors_and_Styles) for styling strings in the terminal.
+
+Although those ANSI codes make the console output nicer, they may make the test data a bit harder to parse and work with for the mere human being (e.g. `Hello [31mWorld[39m!`).
+
+The `createConsole()` function accepts a `stripAnsi` option (defaulting to `false`) to dynamically remove the control characters from what's being logged.
+
+```js
+import { createConsole, getLog, mockConsole } from 'console-testing-library';
+const chalk = require('chalk'); // or any other similar library
+
+const strippingConsole = createConsole({ stripAnsi: true });
+const restore = mockConsole(strippingConsole);
+
+console.log('Hello %s!', chalk.red('World'));
+
+// Yeah! Plain text without any funky ANSI codes.
+expect(getLog().log).toEqual('Hello World!');
+
+restore();
+```
+
 ## Custom matchers
 
 It's often recommended to use `console-testing-library` with Jest's [`toMatchInlineSnapshot`](https://jestjs.io/docs/en/expect#tomatchinlinesnapshotpropertymatchers-inlinesnapshot) matcher. It makes it really easy to test the console output with confidence.

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,4 +1,7 @@
 const { getLog, createConsole, mockConsole, silenceConsole } = require('..');
+const style = require('ansi-styles');
+
+const red = input => `${style.red.open}${input}${style.red.close}`;
 
 expect(jest.isMockFunction(console.log)).toBe(false);
 
@@ -6,6 +9,26 @@ test('simple', () => {
   console.log('Hello %s!', 'World');
 
   expect(getLog().log).toMatchInlineSnapshot(`"Hello World!"`);
+});
+
+test('simple with ansi characters', () => {
+  console.log('Hello %s!', red('World'));
+
+  expect(getLog().log).toMatchInlineSnapshot(`"Hello [31mWorld[39m!"`);
+  expect(getLog().levels.log).toMatchInlineSnapshot(`"Hello [31mWorld[39m!"`);
+  expect(getLog().getRecord('log')).toMatchInlineSnapshot(`"Hello [31mWorld[39m!"`);
+});
+
+test('can strip out ansi characters', () => {
+  const targetConsole = createConsole({ stripAnsi: true });
+  const restore = mockConsole(targetConsole);
+
+  console.log('Hello %s!', red('World'));
+
+  expect(getLog().log).toMatchInlineSnapshot(`"Hello World!"`);
+  expect(getLog().levels.log).toMatchInlineSnapshot(`"Hello World!"`);
+  expect(getLog().getRecord('log')).toMatchInlineSnapshot(`"Hello World!"`);
+  restore();
 });
 
 test('advanced', () => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ export const originalConsole = Console;
 
 type Options = {
   isSilent?: boolean;
+  stripAnsi?: boolean;
 };
 
 export enum ConsoleLevels {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,14 @@
   },
   "dependencies": {
     "jest-snapshot": "^24.9.0",
-    "pretty-format": "^24.9.0"
+    "pretty-format": "^24.9.0",
+    "strip-ansi": "^6.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.4",
     "@babel/core": "^7.7.4",
     "@babel/preset-env": "^7.7.4",
+    "ansi-styles": "^4.3.0",
     "canopic": "^0.2.1"
   },
   "eslintConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,6 +1086,11 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -1097,6 +1102,13 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
 
 any-observable@^0.3.0:
   version "0.3.0"
@@ -1595,10 +1607,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -5138,6 +5162,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
 
 strip-bom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Using 'chalk' (or other alternatives) is quite standard when writing pretty console outputs.

This new option (sets to `false` by default), allows dynamic stripping
of ansi characters to make snapshot comparison easier.